### PR TITLE
Fix encoding problem w/passwords and special chars

### DIFF
--- a/keychain.js
+++ b/keychain.js
@@ -159,7 +159,7 @@ KeychainAccess.prototype.setPassword = function(opts, fn) {
         return;
       }
     } else {
-     fn(null);
+     fn(null, opts.password);
     }
   });
 };

--- a/test/keychain.test.js
+++ b/test/keychain.test.js
@@ -4,6 +4,8 @@ describe('KeychainAccess', function(){
   var testService = 'KeychainAccess#test#' + Date.now();
   var testInternetService = 'KeychainAccess' + Date.now() + '.com';
 
+  var asciiPW = "test";
+
   it('should be running on a mac', function(){
     require('os').platform().should.equal('darwin');
   })
@@ -41,19 +43,21 @@ describe('KeychainAccess', function(){
       })
     });
 
-    describe('when sent { account: "drudge", password: "test", service: "' + testService + '" }', function(){
-      it('should return "test"', function(done){
-        keychain.setPassword({ account: "drudge", password: "test", service: testService }, function(err) {
+    describe('when sent { account: "asciiAccount", password: "' + asciiPW + '", service: "' + testService + '" }', function(){
+      it('should return "' + asciiPW, function(done){
+        keychain.setPassword({ account: "asciiAccount", password: asciiPW, service: testService }, function(err, pass) {
           if (err) throw err;
+          pass.should.equal(asciiPW);
           done();
         });
       });
     });
 
-    describe('when sent { account: "drudge", password: "test", service: "' + testService + '" }', function(){
-      it('should return "test"', function(done){
-        keychain.setPassword({ account: "drudge", password: "test", service: testService }, function(err) {
+    describe('when sent { account: "asciiAccount", password: "' + asciiPW + '", service: "' + testInternetService + '", type:"internet" }', function(){
+      it('should return ' + asciiPW, function(done){
+        keychain.setPassword({ account: "asciiAccount", password: asciiPW, service: testInternetService, type:"internet" }, function(err, pass) {
           if (err) throw err;
+          pass.should.equal(asciiPW);
           done();
         });
       });
@@ -82,8 +86,8 @@ describe('KeychainAccess', function(){
 
     describe('when no account is given', function(){
       it('should return an error', function(done){
-        keychain.setPassword({ password: 'baz', service: testService }, function(err) {
-          if (!err) throw new Error();
+        keychain.getPassword({ password: 'baz', service: testService }, function(err) {
+          err.should.be.instanceOf(Error).and.have.property('message', 'An account is required');
           done();
         });
       });
@@ -91,48 +95,48 @@ describe('KeychainAccess', function(){
 
     describe('when no service is given', function(){
       it('should return an error', function(done){
-        keychain.setPassword({ account: 'foo', password: 'baz' }, function(err) {
-          if (!err) throw new Error();
+        keychain.getPassword({ account: 'foo', password: 'baz' }, function(err) {
+          err.should.be.instanceOf(Error).and.have.property('message', 'A service is required');
           done();
         });
       });
     });
 
-    describe('when sent { account: "drudge", service: "' + testService +'" }', function(){
+    describe('when sent { account: "asciiAccount", service: "' + testService +'" }', function(){
       it('should return "test"', function(done){
-        keychain.getPassword({ account: "drudge", service: testService }, function(err, pass) {
+        keychain.getPassword({ account: "asciiAccount", service: testService }, function(err, pass) {
           if (err) throw err;
 
-          pass.should.equal("test");
+          pass.should.equal(asciiPW);
           done();
         });
       });
     });
 
-    describe('when sent { account: "drudge", service: "' + testService + '#NOTEXIST' +'" }', function(){
+    describe('when sent { account: "asciiAccount", service: "' + testService + '#NOTEXIST' +'" }', function(){
       it('should return an error', function(done){
-        keychain.getPassword({ account: "drudge", service: testService + '#NOTEXIST' }, function(err, pass) {
-          if (!err) throw new Error();
+        keychain.getPassword({ account: "asciiAccount", service: testService + '#NOTEXIST' }, function(err, pass) {
+          err.should.be.instanceOf(Error).and.have.property('message', 'Could not find password');
           done();
         });
       });
     });
 
-    describe('when sent { account: "drudge", service: "' + testInternetService + '", type:"internet" }', function(){
-      it('should return "test"', function(done){
-        keychain.getPassword({ account: "drudge", service: testInternetService, type: "internet" }, function(err, pass) {
+    describe('when sent { account: "asciiAccount", service: "' + testInternetService + '", type:"internet" }', function(){
+      it('should return ' + asciiPW, function(done){
+        keychain.getPassword({ account: "asciiAccount", service: testInternetService, type: "internet" }, function(err, pass) {
           if (err) throw err;
 
-          pass.should.equal("test");
+          pass.should.equal(asciiPW);
           done();
         });
       });
     });
 
-    describe('when sent { account: "drudge", service: "' + testInternetService + '#NOTEXIST", type:"internet" }', function(){
+    describe('when sent { account: "asciiAccount", service: "' + testInternetService + '#NOTEXIST", type:"internet" }', function(){
       it('should return an error', function(done){
-        keychain.getPassword({ account: "drudge", service: testInternetService + '#NOTEXIST', type: "internet" }, function(err, pass) {
-          if (!err) throw new Error();
+        keychain.getPassword({ account: "asciiAccount", service: testInternetService + '#NOTEXIST', type: "internet" }, function(err, pass) {
+          err.should.be.instanceOf(Error).and.have.property('message', 'Could not find password');
           done();
         });
       });
@@ -163,9 +167,9 @@ describe('KeychainAccess', function(){
       });
     });
 
-    describe('when sent { account: "drudge", service: "' + testService + '" }', function(){
+    describe('when sent { account: "asciiAccount", service: "' + testService + '" }', function(){
       it('should return a password of "test"', function(done){
-        keychain.deletePassword({ account: "drudge", service: testService }, function(err) {
+        keychain.deletePassword({ account: "asciiAccount", service: testService }, function(err) {
           if (err) throw err;
           done();
         });
@@ -174,16 +178,16 @@ describe('KeychainAccess', function(){
 
     describe('when sent the same options again', function(){
       it('should return an error', function(done){
-        keychain.deletePassword({ account: "drudge", service: testService }, function(err) {
+        keychain.deletePassword({ account: "asciiAccount", service: testService }, function(err) {
           if (!err) throw new Error();
           done();
         });
       });
     });
 
-    describe('when sent { account: "drudge", service: "' + testInternetService + '", type:"internet" }', function(){
+    describe('when sent { account: "asciiAccount", service: "' + testInternetService + '", type:"internet" }', function(){
       it('should return a password of "test"', function(done){
-        keychain.deletePassword({ account: "drudge", service: testInternetService, type: "internet" }, function(err) {
+        keychain.deletePassword({ account: "asciiAccount", service: testInternetService, type: "internet" }, function(err) {
           if (err) throw err;
           done();
         });
@@ -192,7 +196,7 @@ describe('KeychainAccess', function(){
 
     describe('when sent the same options again', function(){
       it('should return an error', function(done){
-        keychain.deletePassword({ account: "drudge", service: testInternetService, type: "internet" }, function(err) {
+        keychain.deletePassword({ account: "asciiAccount", service: testInternetService, type: "internet" }, function(err) {
           if (!err) throw new Error();
           done();
         });

--- a/test/keychain.test.js
+++ b/test/keychain.test.js
@@ -5,6 +5,8 @@ describe('KeychainAccess', function(){
   var testInternetService = 'KeychainAccess' + Date.now() + '.com';
 
   var asciiPW = "test";
+  var mixedPW = "∆elta";
+  var unicodePW = "∆˚ˆ©ƒ®∂çµ˚¬˙ƒ®†¥";
 
   it('should be running on a mac', function(){
     require('os').platform().should.equal('darwin');
@@ -63,19 +65,21 @@ describe('KeychainAccess', function(){
       });
     });
 
-    describe('when sent { account: "drudge", password: "test", service: "' + testInternetService + '", type:"internet" }', function(){
-      it('should return "test"', function(done){
-        keychain.setPassword({ account: "drudge", password: "test", service: testInternetService, type:"internet" }, function(err) {
+    describe('when sent { account: "unicodeAccount", password: "' + unicodePW + '", service: "' + testService + '" }', function(){
+      it('should return "' + unicodePW, function(done){
+        keychain.setPassword({ account: "unicodeAccount", password: unicodePW, service: testService }, function(err, pass) {
           if (err) throw err;
+          pass.should.equal(unicodePW);
           done();
         });
       });
     });
 
-    describe('when sent { account: "drudge", password: "test", service: "' + testInternetService + '", type:"internet" }', function(){
-      it('should return "test"', function(done){
-        keychain.setPassword({ account: "drudge", password: "test", service: testInternetService, type:"internet" }, function(err) {
+    describe('when sent { account: "mixedAccount", password: "' + mixedPW + '", service: "' + testService + '" }', function(){
+      it('should return "' + mixedPW, function(done){
+        keychain.setPassword({ account: "mixedAccount", password: mixedPW, service: testService }, function(err, pass) {
           if (err) throw err;
+          pass.should.equal(mixedPW);
           done();
         });
       });
@@ -142,6 +146,27 @@ describe('KeychainAccess', function(){
       });
     });
 
+    describe('when sent { account: "unicodeAccount", service: "' + testService +'" }', function(){
+      it('should return ' + unicodePW, function(done){
+        keychain.getPassword({ account: "unicodeAccount", service: testService }, function(err, pass) {
+          if (err) throw err;
+
+          pass.should.equal(unicodePW);
+          done();
+        });
+      });
+    });
+
+    describe('when sent { account: "mixedAccount", service: "' + testService +'" }', function(){
+      it('should return ' + mixedPW, function(done){
+        keychain.getPassword({ account: "mixedAccount", service: testService }, function(err, pass) {
+          if (err) throw err;
+
+          pass.should.equal(mixedPW);
+          done();
+        });
+      });
+    });
   });
 
   describe('.deletePassword(opts, fn)', function(){


### PR DESCRIPTION
Keychain output of passwords does some strange things with special characters, this PR resolves this issue.

* If the password contains no special characters it outputs just a string representation (e.g. for user input `pass`):
`password: pass`

* If the password contains a mix of special characters and ascii it outputs a hex and string representation (e.g. for user input `passWith\`):
`password: 0x70617373576974685C  "passWith\134"`
Note: `\134` is \ in octal

* If the password contains no ascii it outputs just the hex representation (e.g. for user input ∆˚ˆ©ƒ®∂çµ˚¬˙ƒ®†¥)':
`password: 0xE28886CB9ACB86C2A9C692C2AEE28882C3A7C2B5CB9AC2ACCB99C692C2AEE280A0C2A5`

This PR uses the hex representation when available and explicitly parses that as UTF-8, and falls back to the original method for the ascii only passwords.