### PR TITLE
Handle passwords which are hex strings correctly

### DIFF
--- a/keychain.js
+++ b/keychain.js
@@ -105,7 +105,9 @@ KeychainAccess.prototype.getPassword = function(opts, fn) {
       //
       // e.g. password '∆˚ˆ©ƒ®∂çµ˚¬˙ƒ®†¥' becomes:
       // password: 0xE28886CB9ACB86C2A9C692C2AEE28882C3A7C2B5CB9AC2ACCB99C692C2AEE280A0C2A5
-      if (/0x([0-9a-fA-F]+)/.test(password)) {
+      // 
+      // But beware of when the password itself is a hex-encoded string; in that case it'll be surrounded in quotes
+      if (/[^"]0x([0-9a-fA-F]+)/.test(password)) {
         var hexPassword = password.match(/0x([0-9a-fA-F]+)/, '')[1];
         fn(null, Buffer.from(hexPassword, 'hex').toString());
       }


### PR DESCRIPTION
If you have a password saved which is a hex-encoded string, that is an ASCII string such as "0x1234" then the current code would see the 0x1234 and attempt to decode it, which is incorrect. `security` will output the hex string in quotes, so we can detect when this is the case and not attempt to decode the string.