### PR TITLE
Improvement of detecting hashed password

### DIFF
--- a/keychain.js
+++ b/keychain.js
@@ -105,7 +105,7 @@ KeychainAccess.prototype.getPassword = function(opts, fn) {
       //
       // e.g. password '∆˚ˆ©ƒ®∂çµ˚¬˙ƒ®†¥' becomes:
       // password: 0xE28886CB9ACB86C2A9C692C2AEE28882C3A7C2B5CB9AC2ACCB99C692C2AEE280A0C2A5
-      if (/0x([0-9a-fA-F]+)/.test(password)) {
+      if (/password: 0x([0-9a-fA-F]+)/.test(password)) {
         var hexPassword = password.match(/0x([0-9a-fA-F]+)/, '')[1];
         fn(null, Buffer.from(hexPassword, 'hex').toString());
       }


### PR DESCRIPTION
The current regular expression `/0x([0-9a-fA-F]+)/`, as well as the one shown in the [PR]( https://github.com/drudge/node-keychain/pull/9) `/[^"]0x([0-9a-fA-F]+)/`, are used to check if a password is encoded in hex format. However, in some cases, they can give false information.

Let's take the following string as an example:

```
{"environments": {"ENV_1": {"Id": "abcde1230xbjcde","path": "/Users/user/config.json"}}}
```

The previously mentioned regular expressions will find the `0xb` fragment in the password, treating it as a hex-encoded password, when in reality it is just a text fragment within the text password string. This can result in returning the wrong password value.

To improve this, I suggest changing the regex to `/password: 0x([0-9a-fA-F]+)/`, so that it always checks only the first characters of the password after the `password:` phrase, which is consistent with how passwords are actually saved in the keychain.