### PR TITLE
Add support to creaste and delete keychains.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The available
 keychain.setPassword(options[, callback]);
 keychain.getPassword(options, callback);
 keychain.deletePassword(options[, callback]);
+keychain.createKeychain(options[, callback]);
+keychain.deleteKeychain(options[, callback]);
 ```
 
 ### Options
@@ -57,6 +59,7 @@ Available params you can pass to the options object:
 | `service` | Specify service name (required) |
 | `password` | Specify password to be added (required for `setPassword`) |
 | `type` | The type of password to get or save. Supported values are `generic` and `internet`. See [docs](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/security.1.html). Default: `generic` |
+| `keychainName` | Specify the name of the keychain (required for 'createKeychain' and 'deleteKeychain') |
 
 ## Contributors
 

--- a/keychain.js
+++ b/keychain.js
@@ -244,6 +244,90 @@ KeychainAccess.prototype.deletePassword = function(opts, fn) {
   });
 };
 
+/**
+* Create a new keychain to be used in the system.
+*
+* @param {Object} opts Object containing 'keychainName' and `password`
+* @param {Function} fn Callback
+* @api public
+*/
+KeychainAccess.prototype.createKeychain = function(opts, fn) {
+  opts = opts || {};
+  fn = fn || noop;
+
+  if (!opts.keychainName) {
+    err = new KeychainAccess.errors.NoKeychainNameProvidedError();
+    fn(err, null);
+    return;
+  }
+
+  if (!opts.password) {
+    err = new KeychainAccess.errors.NoPasswordProvidedError();
+    fn(err, null);
+    return;
+  }
+
+  //console.log(this.executablePath + " create-keychain -p " + opts.password + " " + opts.keychainName);
+  var security = spawn(this.executablePath, [ 'create-keychain', '-p', opts.password, opts.keychainName]);
+
+  security.on('error', function(err) {
+    err = new KeychainAccess.errors.ServiceFailureError(null, err.message);
+    fn(err, null);
+    return;
+  });
+
+  security.on('close', function(code, signal) {
+    if (code !== 0) {
+      var msg = 'Security returned a non-successful error code: ' + code;
+      err = new KeychainAccess.errors.ServiceFailureError(msg);
+      err.exitCode = code;
+      fn(err);
+      return;
+    } else {
+      fn(null, opts.keychainName);
+    }
+  });
+};
+
+/**
+* Delete a keychain from the system.
+*
+* @param {Object} opts Object containing 'keychainName'
+* @param {Function} fn Callback
+* @api public
+*/
+KeychainAccess.prototype.deleteKeychain = function(opts, fn) {
+  opts = opts || {};
+  fn = fn || noop;
+
+  if (!opts.keychainName) {
+    err = new KeychainAccess.errors.NoKeychainNameProvidedError();
+    fn(err, null);
+    return;
+  }
+
+  var security = spawn(this.executablePath, [ 'delete-keychain', opts.keychainName]);
+
+  security.on('error', function(err) {
+    err = new KeychainAccess.errors.ServiceFailureError(null, err.message);
+    fn(err, null);
+    return;
+  });
+
+  security.on('close', function(code, signal) {
+    if (code !== 0) {
+      var msg = 'Security returned a non-successful error code: ' + code;
+      err = new KeychainAccess.errors.ServiceFailureError(msg);
+      err.exitCode = code;
+      fn(err);
+      return;
+    } else {
+      fn(null, opts.keychainName);
+    }
+  });
+
+};
+
 function errorClass(code, defaultMsg) {
   var errorType = code + 'Error';
   var ErrorClass = function (msg, append) {
@@ -265,6 +349,7 @@ errorClass('NoServiceProvided', 'A service is required');
 errorClass('NoPasswordProvided', 'A password is required');
 errorClass('ServiceFailure', 'Keychain failed to start child process: ');
 errorClass('PasswordNotFound', 'Could not find password');
+errorClass('NoKeychainNameProvided', 'A keychain name is required');
 
 
 /**

--- a/test/keychain.test.js
+++ b/test/keychain.test.js
@@ -7,6 +7,7 @@ describe('KeychainAccess', function(){
   var asciiPW = "test";
   var mixedPW = "∆elta";
   var unicodePW = "∆˚ˆ©ƒ®∂çµ˚¬˙ƒ®†¥";
+  var keychainName = "test.keychain";
 
   it('should be running on a mac', function(){
     require('os').platform().should.equal('darwin');
@@ -229,6 +230,88 @@ describe('KeychainAccess', function(){
       });
     });
 
+  });
+
+  describe('.createKeychain(opts, fn)', function(){
+    describe('when no keychain name is given', function(){
+      it('should return an error', function(done){
+        keychain.createKeychain({ password: 'baz' }, function(err) {
+          if (err) {
+            done();
+            return;
+          }
+          done(new Error());
+        });
+      })
+    });
+
+    describe('when no password is given', function(){
+      it('should return an error', function(done){
+        keychain.createKeychain({ keychainName: keychainName }, function(err) {
+          if (err) {
+            done();
+            return;
+          }
+          done(new Error());
+        });
+      })
+    });
+
+    describe('when sent { keychainName: "' + keychainName + '", password: "' + asciiPW +'" }', function(){
+      it('should return ' + keychainName, function(done){
+        keychain.createKeychain({ keychainName: keychainName, password: asciiPW }, function(err, name) {
+          if (err) throw err;
+
+          name.should.equal(keychainName);
+          done();
+        });
+      });
+    });
+
+    describe('when sent the same options again', function(){
+      it('should return an error', function(done){
+        keychain.createKeychain({ keychainName: keychainName, password: asciiPW }, function(err) {
+          if (!err) throw new Error();
+          done();
+        });
+      });
+    });
+
+  });
+
+  describe('.deleteKeychain(opts, fn)', function(){
+
+    describe('when no keychain name is given', function(){
+      it('should return an error', function(done){
+        keychain.deleteKeychain({ password: 'baz' }, function(err) {
+          if (err) {
+            done();
+            return;
+          }
+          done(new Error());
+        });
+      })
+    });
+
+    describe('when sent { keychainName: "' + keychainName + '"}', function(){
+      it('should return ' + keychainName, function(done){
+        keychain.deleteKeychain({ keychainName: keychainName }, function(err, name) {
+          if (err) throw err;
+
+          name.should.equal(keychainName);
+          done();
+        });
+      });
+    });
+
+    describe('when sent the same options again', function(){
+      it('should return an error', function(done){
+        keychain.deletePassword({ account: keychainName, password: asciiPW }, function(err) {
+          if (!err) throw new Error();
+          done();
+        });
+      });
+    });
   });
 
 });


### PR DESCRIPTION
Add two new calls that allow to create and delete keychains so that a user can create a clean new one to be used in the system. This is useful when we do not want to clutter the users default keychain.